### PR TITLE
fixed: focus safari bug

### DIFF
--- a/TodoApp.js
+++ b/TodoApp.js
@@ -109,6 +109,8 @@ TodoApp.prototype.refresh = function (path) {
     var edit = document.getElementById(item._id);
     if (edit) {
         edit.focus();
+        // safari text select fix
+        edit.value = edit.value;
         // TODO scroll into view
     }
     // set URI


### PR DESCRIPTION
Bug: in Apple Safari browser text always selected instead of just focused. Fixed. Simple, but it works.
