### PR TITLE
use react.min.js from node_modules/react

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: libs dist todo
 
 libs:
 	npm install
-	curl -L -o dist/react-0.11.2.min.js http://fb.me/react-0.11.2.min.js
+	cp node_modules/react/dist/react.min.js dist/react.min.js
 
 dist: $(TARGETS)
 

--- a/TodoAppServer.js
+++ b/TodoAppServer.js
@@ -141,7 +141,7 @@ if (argv.repl) {
 function loadHtmlTemplate () {
     // The code depends on the version of React.
     // Better if React versions match (here and in package.json)
-    var reactUrl = argv.cdn ? 'http://fb.me/react-0.11.2.min.js' : '/dist/react-0.11.2.min.js'
+    var reactUrl = argv.cdn ? 'http://fb.me/react-0.11.2.min.js' : '/dist/react.min.js'
     var css1 = fs.readFileSync('./css/base.css').toString();
     var css2 = fs.readFileSync('./css/add.css').toString();
     var css3 = fs.readFileSync('./css/touch.css').toString();

--- a/todo.appcache
+++ b/todo.appcache
@@ -2,15 +2,12 @@ CACHE MANIFEST
 #2014-10-17 v0.0.7
 
 CACHE:
-/dist/react-0.11.2.min.js
+/dist/react.min.js
 /dist/TodoApp.app.js
 /fake_auth_init.js
 /css/base.css
 /css/add.css
 /css/bg.png
-*
-
-NETWORK:
 
 FALLBACK:
 / /offline.html


### PR DESCRIPTION
Why downloading react.min.js from fb.me when we already have one in node_modules/react/dist/ ?
